### PR TITLE
HOMIS-1643 機能：【共通】ORCA API処理の変更により、Homis側の処理を更新する・orca-api

### DIFF
--- a/lib/orca_api/client.rb
+++ b/lib/orca_api/client.rb
@@ -147,8 +147,17 @@ module OrcaApi # :nodoc:
     def call(path, params: {}, body: nil, http_method: :post, format: "json", output_io: nil)
       path = "#{@path_prefix}#{path}"
       http_request = make_request(http_method, path, params, body, format)
-      response = do_call http_request, output_io
-      @after_call&.call(http_request, response, host, status_code)
+      response = nil
+      error = nil
+      begin
+        response = do_call http_request, output_io
+      rescue HttpError => e
+        response = e.response
+        error = e
+        raise
+      ensure
+        @after_call&.call(http_request, response, host, status_code, error)
+      end
 
       response
     end
@@ -429,6 +438,9 @@ module OrcaApi # :nodoc:
       end
     end
 
+    SESSION_INITIALIZING_MESSAGE = "マスター更新中です。しばらくお待ちください。".freeze
+    private_constant :SESSION_INITIALIZING_MESSAGE
+
     def do_request(http, request, output_io)
       http.request(request) do |response|
         @status_code = response&.code.to_s
@@ -444,7 +456,12 @@ module OrcaApi # :nodoc:
             return response.body
           end
         else
-          raise HttpError, response
+          # Byte-level compare (.b) avoids Encoding::CompatibilityError when body comes back as ASCII-8BIT.
+          if response.code == "503" && response.body.to_s.b.include?(SESSION_INITIALIZING_MESSAGE.b)
+            raise SessionInitializingError, response
+          else
+            raise HttpError, response
+          end
         end
       end
     end

--- a/lib/orca_api/error.rb
+++ b/lib/orca_api/error.rb
@@ -7,11 +7,24 @@ module OrcaApi
 
   # HTTP通信時に発生したエラーを表現するクラス
   class HttpError < Error
-    attr_reader :response # エラーが発生したHTTP通信のNet::HTTPResponseオブジェクト
+    # @!attribute [r] response
+    #   エラーが発生したHTTP通信のNet::HTTPResponseオブジェクト
+    # @!attribute [r] body
+    #   Response body, cached inside Net::HTTP block.
+    attr_reader :response, :body
 
     def initialize(response)
       @response = response
+      # Read body inside the block to cache it; accessing after block exit raises IOError.
+      @body = response.body.to_s
+      super("#{response.message} (#{response.code})")
+    rescue IOError
+      @body = ""
       super("#{response.message} (#{response.code})")
     end
+  end
+
+  # Raised for 503 responses with the WebORCA/WebQKAN session-init marker
+  class SessionInitializingError < HttpError
   end
 end

--- a/spec/orca_api/blob_service_spec.rb
+++ b/spec/orca_api/blob_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe OrcaApi::BlobService, :orca_api_mock do
     context "異常系" do
       context "404 Not Found" do
         it do
-          error = OrcaApi::HttpError.new(double("Net::HTTPNotFound", message: "Not Found", code: "404"))
+          error = OrcaApi::HttpError.new(double("Net::HTTPNotFound", message: "Not Found", code: "404", body: ""))
           expect(orca_api).to receive(:call).
             with("/blobapi/#{uid}", http_method: :get, format: nil, output_io: output_io).once.and_raise(error)
 

--- a/spec/orca_api/client_spec.rb
+++ b/spec/orca_api/client_spec.rb
@@ -305,6 +305,77 @@ RSpec.describe OrcaApi::Client do
         end
       end
 
+      context "503 response with master-update marker" do
+        it "raises SessionInitializingError" do
+          path = "/api01rv2/patientgetv2"
+          stub_request(:post, URI.join(request_url, path, "?#{query}")).
+            to_return(body: "マスター更新中です。しばらくお待ちください。", status: 503)
+
+          expect { orca_api.call(path) }.to raise_error(OrcaApi::SessionInitializingError)
+        end
+
+        it "SessionInitializingError is a subclass of HttpError" do
+          expect(OrcaApi::SessionInitializingError.ancestors).to include(OrcaApi::HttpError)
+        end
+      end
+
+      context "503 response without master-update marker" do
+        it "raises HttpError (not SessionInitializingError)" do
+          path = "/api01rv2/patientgetv2"
+          stub_request(:post, URI.join(request_url, path, "?#{query}")).
+            to_return(body: "Service Unavailable", status: 503)
+
+          expect { orca_api.call(path) }.to raise_error(OrcaApi::HttpError) { |e|
+            expect(e).not_to be_a(OrcaApi::SessionInitializingError)
+          }
+        end
+      end
+
+      context "after_call hook" do
+        let(:captured_error) { [] }
+        let(:options) {
+          {
+            after_call: proc do |_request, _response, _host, _status_code, error|
+              captured_error << error
+            end,
+          }
+        }
+
+        it "receives the error object as the 5th argument on error" do
+          path = "/api01rv2/patientgetv2"
+          stub_request(:post, URI.join(request_url, path, "?#{query}")).
+            to_return(body: "マスター更新中です。しばらくお待ちください。", status: 503)
+
+          expect { orca_api.call(path) }.to raise_error(OrcaApi::SessionInitializingError)
+          expect(captured_error.last).to be_a(OrcaApi::SessionInitializingError)
+        end
+
+        it "receives nil for the error argument on success" do
+          path = "/api01rv2/patientgetv2"
+          stub_request(:post, URI.join(request_url, path, "?#{query}")).to_return(body: "{}", status: 200)
+
+          orca_api.call(path)
+          expect(captured_error.last).to be_nil
+        end
+      end
+
+      context "HttpError#body" do
+        it "is accessible outside the Net::HTTP block" do
+          path = "/api01rv2/patientgetv2"
+          body = "error detail"
+          stub_request(:post, URI.join(request_url, path, "?#{query}")).to_return(body: body, status: 500)
+
+          captured = nil
+          begin
+            orca_api.call(path)
+          rescue OrcaApi::HttpError => e
+            captured = e
+          end
+
+          expect(captured.body).to eq(body)
+        end
+      end
+
       context "リクエストのヘッダとボディが1MiB以上であるため、Net::HTTP#requestでErrno::EPIPEの例外が発生する" do
         it do
           path = "/api01rv2/patientlst1v2"


### PR DESCRIPTION
## Specification

Detect ORCA/WebQKAN session-init at the gem level — raise a dedicated `SessionInitializingError` so consumers can distinguish it from a generic `HttpError`, cache the response body, and pass the error to the `after_call` hook.

- https://mics-homis.backlog.com/view/HOMIS-1643

#### Summary

- Raise `OrcaApi::SessionInitializingError` on 503 responses whose body contains the master-update marker.
- Cache `HttpError#body` inside the `Net::HTTP` block so it survives outside.
- Pass `error` to the `after_call` hook so callers can log failed requests.

## Related PRs

- homis
  - https://github.com/hl-management/homis/pull/2781
- homis-frontend-backoffice
  - https://github.com/hl-management/homis-frontend-backoffice/pull/1572
- homis-frontend-medical
  - https://github.com/hl-management/homis-frontend-medical/pull/3073

### orca-api gem

**New**

- `OrcaApi::SessionInitializingError` — subclass of `HttpError` raised for 503 responses with the WebORCA/WebQKAN session-init marker.

**Modified**

- `OrcaApi::Client#call` — wrap `do_call` in `begin/ensure` to capture `HttpError`; pass `error` as 5th arg to the `@after_call` hook.
- `OrcaApi::Client#do_request` — on 503, byte-compare body with `マスター更新中です。しばらくお待ちください。` marker; raise `SessionInitializingError` if it matches, else `HttpError`.
- `OrcaApi::HttpError` — cache `body` inside the `Net::HTTP` block to avoid `IOError` when accessed later; add `attr_reader :body`.