### PR TITLE
HOMIS-113 機能:【医療事務】訪問看護実績をhomisへ同期する・orca-api

### DIFF
--- a/lib/orca_api/orca_qkan_service.rb
+++ b/lib/orca_api/orca_qkan_service.rb
@@ -27,6 +27,8 @@ module OrcaApi
   #   @see OrcaQkanService::QkanMultiMasterCodeListService#get
   # @!method update_qkan_service_use_service
   #   @see OrcaQkanService::QkanServiceUseService#update
+  # @!method get_qkan_service_use_service
+  #   @see OrcaQkanService::QkanServiceUseService#get
   # @!method list_qkan_meisai_service
   #   @see OrcaQkanService::QkanMeisaiService#list
 

--- a/lib/orca_api/orca_qkan_service/qkan_service_use_service.rb
+++ b/lib/orca_api/orca_qkan_service/qkan_service_use_service.rb
@@ -10,6 +10,22 @@ module OrcaApi
         )
       end
 
+      # 予定・実績情報取得API
+      def get(patient_id, service_ym)
+        orca_api.call(
+          "/service01/serviceinf",
+          format: 'xml',
+          body: <<-XML
+              <data>
+                <serviceinfreq type="record">
+                  <Patient_Id type="string">#{patient_id}</Patient_Id>
+                  <Service_YM type="string">#{service_ym}</Service_YM>
+                </serviceinfreq>
+              </data>
+          XML
+        )
+      end
+
       private
 
       def build_xml_request(params)

--- a/spec/orca_api/qkan_service/qkan_service_use_service_spec.rb
+++ b/spec/orca_api/qkan_service/qkan_service_use_service_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require "orca_api/orca_qkan_service/qkan_service_use_service"
+
+RSpec.describe OrcaApi::OrcaQkanService::QkanServiceUseService do # rubocop:disable RSpec/SpecFilePathFormat
+  orca_model = 'OrcaApi::Api'
+  let(:orca_api) { instance_double(orca_model, call: api_response) }
+  let(:service) { described_class.new(orca_api) }
+
+  describe "#get" do
+    let(:api_response) do
+      {
+        success: true,
+        response: "処理終了"
+      }
+    end
+
+    it "calls the 予定・実績情報取得API endpoint with the patient id and service month" do
+      expect(orca_api).to receive(:call).with(
+        "/service01/serviceinf",
+        format: 'xml',
+        body: include('<serviceinfreq type="record">').
+              and(include('<Patient_Id type="string">12345</Patient_Id>')).
+              and(include('<Service_YM type="string">2026-05</Service_YM>'))
+      )
+
+      service.get("12345", "2026-05")
+    end
+
+    it "returns the API response" do
+      result = service.get("12345", "2026-05")
+
+      expect(result[:success]).to be true
+      expect(result[:response]).to include("処理終了")
+    end
+  end
+end


### PR DESCRIPTION
## Specification

Add the QKAN 予定・実績情報取得API (serviceinf) to the orca_api gem.

- https://mics-homis.backlog.com/view/HOMIS-113

#### Summary

- Add `QkanServiceUseService#get(patient_id, service_ym)` that calls POST `/service01/serviceinf` (xml) with `Patient_Id` + `Service_YM`, and expose it via `OrcaQkanService`.

## Related PRs

- homis
  - backend: https://github.com/hl-management/homis/pull/2834
  - backfill: https://github.com/hl-management/homis/pull/2836
- homis-frontend-backoffice
  - https://github.com/hl-management/homis-frontend-backoffice/pull/1598

### orca-api gem

**Modified**

- Services
  - `QkanServiceUseService#get` — new method posting to `/service01/serviceinf` with `Patient_Id` + `Service_YM`
  - `OrcaQkanService` — expose the new service method

**New**

- Specs
  - `qkan_service_use_service_spec` — cover the new `get` request
