### PR TITLE
HOMIS-1550 機能：【医療事務】売上データ出力機能の追加・orca-api

### DIFF
--- a/lib/orca_api/client.rb
+++ b/lib/orca_api/client.rb
@@ -155,6 +155,12 @@ module OrcaApi # :nodoc:
         response = e.response
         error = e
         raise
+      rescue StandardError => e
+        # Connection-level failures (e.g. Errno::ECONNREFUSED, timeouts) are not
+        # HttpError; still hand the error to after_call so it logs the failure
+        # instead of treating the nil response as a normal one.
+        error = e
+        raise
       ensure
         @after_call&.call(http_request, response, host, status_code, error)
       end
@@ -227,6 +233,9 @@ module OrcaApi # :nodoc:
     # @!method new_statistics_form_service
     # @return [StatisticsFormService] StatisticsFormServiceインスタンス
 
+    # @!method new_statistics_data_service
+    # @return [StatisticsDataService] StatisticsDataServiceインスタンス
+
     # @!method new_interruption_form_service
     # @return [InterruptionService] InterruptionServiceインスタンス
 
@@ -277,6 +286,7 @@ module OrcaApi # :nodoc:
       ReceiptDataService
       ReceiptService
       RehabilitationCommentService
+      StatisticsDataService
       StatisticsFormService
       SubjectiveService
       UserService

--- a/lib/orca_api/statistics_data_service.rb
+++ b/lib/orca_api/statistics_data_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative "service"
+
+module OrcaApi
+  # Wraps the CSV data output (statistics data) API.
+  # @see https://apic.orcamo.co.jp/api-council/members/standards/?haori_statistics_form#api2
+  class StatisticsDataService < Service
+    MODES = {
+      daily: "Daily",
+      monthly: "Monthly"
+    }.freeze
+    private_constant :MODES
+
+    # @param mode [Symbol]
+    #   mode
+    #   - :daily
+    #   - :monthly
+    # @return [OrcaApi::Result]
+    def list(mode:)
+      raise ArgumentError unless MODES.key? mode
+
+      Result.new(
+        orca_api.call(
+          "/orca07/statisticsdatav3",
+          body: {
+            statistics_datav3req: {
+              "Request_Number" => "00",
+              "Karte_Uid" => orca_api.karte_uid,
+              "Statistics_Mode" => MODES[mode]
+            }
+          }
+        )
+      )
+    end
+
+    # @param data_info [Hash]
+    #   an element of the output-data list returned by #list
+    #   (a Hash with Statistics_Group_No/Statistics_Processing_Number/Statistics_Serial_Number/
+    #    Statistics_Character_Code/Statistics_File_Name)
+    # @param mode [Symbol]
+    #   mode
+    #   - :daily
+    #   - :monthly
+    # @return [OrcaApi::Result]
+    def get(data_info, mode:)
+      raise ArgumentError unless MODES.key? mode
+
+      Result.new(
+        orca_api.call(
+          "/orca07/statisticsdatav3",
+          body: {
+            statistics_datav3req: {
+              "Request_Number" => "01",
+              "Karte_Uid" => orca_api.karte_uid,
+              "Statistics_Mode" => MODES[mode],
+              "Statistics_Data_Information" => {
+                "Statistics_Group_No" => data_info["Statistics_Group_No"],
+                "Statistics_Processing_Number" => data_info["Statistics_Processing_Number"],
+                "Statistics_Serial_Number" => data_info["Statistics_Serial_Number"],
+                "Statistics_Character_Code" => data_info["Statistics_Character_Code"],
+                "Statistics_File_Name" => data_info["Statistics_File_Name"]
+              }
+            }
+          }
+        )
+      )
+    end
+  end
+end

--- a/lib/orca_api/statistics_form_service.rb
+++ b/lib/orca_api/statistics_form_service.rb
@@ -161,6 +161,34 @@ module OrcaApi
       )
     end
 
+    # Generic processing execution to run an arbitrary statistics program.
+    #
+    # @param program_name [String] statistics program name
+    # @param parameters [Array<Hash>] each with Statistics_Parm_No/Class/Value
+    #   (Statistics_Parm_Label/Required_Item optional)
+    # @param mode [Symbol] :daily or :monthly
+    # @return [CreateResult]
+    def create_report(program_name:, parameters:, mode:)
+      raise ArgumentError unless MODES.key? mode
+
+      CreateResult.new(
+        orca_api.call(
+          "/orca51/statisticsformv3",
+          body: {
+            statistics_formv3req: {
+              "Request_Number" => "01",
+              "Karte_Uid" => orca_api.karte_uid,
+              "Statistics_Mode" => MODES[mode],
+              "Statistics_Processing_List_Information" => [{
+                "Statistics_Program_Name" => program_name,
+                "Statistics_Parameter_Information" => extract_statistics_parameter_information(parameters)
+              }]
+            }
+          }
+        )
+      )
+    end
+
     # @param create_result [CreateResult]
     # @return [CreatedResult] 処理確認のレスポンスクラス
     def created(create_result)

--- a/spec/orca_api/statistics_data_service_spec.rb
+++ b/spec/orca_api/statistics_data_service_spec.rb
@@ -1,0 +1,155 @@
+require "spec_helper"
+require_relative "shared_examples"
+
+RSpec.describe OrcaApi::StatisticsDataService, :orca_api_mock do
+  let(:service) { described_class.new(orca_api) }
+
+  describe "#list" do
+    it "calls the API correctly" do
+      expect_orca_api_call(
+        [
+          {
+            path: "/orca07/statisticsdatav3",
+            body: {
+              statistics_datav3req: {
+                "Request_Number" => "00",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Statistics_Mode" => "Monthly"
+              }
+            },
+            response: {
+              "statistics_datav3res" => {
+                "Api_Result" => "000",
+                "Api_Result_Message" => "情報取得終了",
+                "Statistics_Data_List_Information" => [
+                  {
+                    "Statistics_Group_No" => "20260529165253",
+                    "Statistics_Processing_Number" => "0001",
+                    "Statistics_Serial_Number" => "0001",
+                    "Statistics_Character_Code" => "Shift_JIS",
+                    "Statistics_File_Name" => "01shinryoutensugekkei_202605.csv",
+                    "Statistics_Output_Count" => "00006",
+                    "Statistics_Data_Title" => "保険別診療点数月計表",
+                    "Statistics_Create_Date" => "2026-05-29"
+                  }
+                ]
+              }
+            }.to_json
+          }
+        ],
+        binding
+      )
+
+      result = service.list mode: :monthly
+      expect(result.ok?).to be true
+      first_entry = result.body["Statistics_Data_List_Information"].first
+      expect(first_entry["Statistics_File_Name"]).to eq("01shinryoutensugekkei_202605.csv")
+    end
+
+    it "raises for an unsupported mode" do
+      expect {
+        service.list mode: :yearly
+      }.to raise_error ArgumentError
+    end
+  end
+
+  describe "#get" do
+    it "calls the API correctly" do
+      data_info = {
+        "Statistics_Group_No" => "20260529165253",
+        "Statistics_Processing_Number" => "0001",
+        "Statistics_Serial_Number" => "0001",
+        "Statistics_Character_Code" => "Shift_JIS",
+        "Statistics_File_Name" => "01shinryoutensugekkei_202605.csv"
+      }
+
+      expect_orca_api_call(
+        [
+          {
+            path: "/orca07/statisticsdatav3",
+            body: {
+              statistics_datav3req: {
+                "Request_Number" => "01",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Statistics_Mode" => "Monthly",
+                "Statistics_Data_Information" => {
+                  "Statistics_Group_No" => "20260529165253",
+                  "Statistics_Processing_Number" => "0001",
+                  "Statistics_Serial_Number" => "0001",
+                  "Statistics_Character_Code" => "Shift_JIS",
+                  "Statistics_File_Name" => "01shinryoutensugekkei_202605.csv"
+                }
+              }
+            },
+            response: {
+              "statistics_datav3res" => {
+                "Api_Result" => "000",
+                "Api_Result_Message" => "情報取得終了",
+                "Data_Id_Information" => [
+                  { "Data_Id" => "blob:abc" }
+                ]
+              }
+            }.to_json
+          }
+        ],
+        binding
+      )
+
+      result = service.get data_info, mode: :monthly
+      expect(result.ok?).to be true
+      expect(result.body["Data_Id_Information"].first["Data_Id"]).to eq("blob:abc")
+    end
+
+    it "sends Statistics_Mode from the given mode" do
+      data_info = {
+        "Statistics_Group_No" => "20260529165253",
+        "Statistics_Processing_Number" => "0001",
+        "Statistics_Serial_Number" => "0001",
+        "Statistics_Character_Code" => "Shift_JIS",
+        "Statistics_File_Name" => "01shinryoutensugekkei_202605.csv"
+      }
+
+      expect_orca_api_call(
+        [
+          {
+            path: "/orca07/statisticsdatav3",
+            body: {
+              statistics_datav3req: {
+                "Request_Number" => "01",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Statistics_Mode" => "Daily",
+                "Statistics_Data_Information" => {
+                  "Statistics_Group_No" => "20260529165253",
+                  "Statistics_Processing_Number" => "0001",
+                  "Statistics_Serial_Number" => "0001",
+                  "Statistics_Character_Code" => "Shift_JIS",
+                  "Statistics_File_Name" => "01shinryoutensugekkei_202605.csv"
+                }
+              }
+            },
+            response: {
+              "statistics_datav3res" => {
+                "Api_Result" => "000",
+                "Api_Result_Message" => "情報取得終了",
+                "Data_Id_Information" => [
+                  { "Data_Id" => "blob:abc" }
+                ]
+              }
+            }.to_json
+          }
+        ],
+        binding
+      )
+
+      result = service.get data_info, mode: :daily
+      expect(result.ok?).to be true
+      expect(result.body["Data_Id_Information"].first["Data_Id"]).to eq("blob:abc")
+    end
+
+    it "raises for an unsupported mode" do
+      expect {
+        service.get({}, mode: :yearly)
+      }.to raise_error ArgumentError
+    end
+  end
+end

--- a/spec/orca_api/statistics_form_service_spec.rb
+++ b/spec/orca_api/statistics_form_service_spec.rb
@@ -119,6 +119,68 @@ RSpec.describe OrcaApi::StatisticsFormService, :orca_api_mock do
     end
   end
 
+  describe "#create_report" do
+    it "calls the API correctly" do
+      expect_orca_api_call(
+        [
+          {
+            path: "/orca51/statisticsformv3",
+            body: {
+              statistics_formv3req: {
+                "Request_Number" => "01",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Statistics_Mode" => "Monthly",
+                "Statistics_Processing_List_Information" => [
+                  {
+                    "Statistics_Program_Name" => "A00000M500",
+                    "Statistics_Parameter_Information" => [
+                      {
+                        "Statistics_Parm_No" => "01",
+                        "Statistics_Parm_Class" => "YM",
+                        "Statistics_Parm_Label" => nil,
+                        "Statistics_Parm_Required_Item" => nil,
+                        "Statistics_Parm_Value" => "2026-05"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            response: {
+              "statistics_formv3res" => {
+                "Api_Result" => "000",
+                "Api_Result_Message" => "情報取得終了",
+                "Statistics_Mode" => "Monthly",
+                "Statistics_Processing_List_Information" => [
+                  {
+                    "Statistics_Program_No" => "001",
+                    "Statistics_Program_Name" => "A00000M500",
+                  }
+                ]
+              }
+            }.to_json
+          }
+        ],
+        binding
+      )
+
+      result = service.create_report(
+        program_name: "A00000M500",
+        parameters: [
+          { "Statistics_Parm_No" => "01", "Statistics_Parm_Class" => "YM", "Statistics_Parm_Value" => "2026-05" }
+        ],
+        mode: :monthly
+      )
+      expect(result.ok?).to be true
+    end
+
+    it "raises for an unsupported mode" do
+      expect {
+        service.create_report(program_name: "A00000M500", parameters: [], mode: :yearly)
+      }.to raise_error ArgumentError
+    end
+  end
+
   describe "#created" do
     let(:create_result) do
       OrcaApi::StatisticsFormService::ListResult.new(


### PR DESCRIPTION
## Specification

Add the ORCA statistics report / data-output APIs used to fetch the A00000M500 保険別診療点数月計表 report.

- https://mics-homis.backlog.com/view/HOMIS-1550

#### Summary

- Add `StatisticsDataService` (list / get of the CSV data output on `/orca07/statisticsdatav3`).
- Add `StatisticsFormService#create_report` to run an arbitrary statistics program with parameters (`/orca51/statisticsformv3`).
- Register `new_statistics_data_service` and hand connection-level errors to `after_call`.

## Related PRs

- homis
  - https://github.com/hl-management/homis/pull/2880
- homis-frontend-backoffice
  - https://github.com/hl-management/homis-frontend-backoffice/pull/1628
- homis-frontend-medical
  - https://github.com/hl-management/homis-frontend-medical/pull/3156

### orca-api gem

**New**

- Services
  - `OrcaApi::StatisticsDataService` — `list(mode:)` (Request_Number 00) and `get(data_info, mode:)` (Request_Number 01) against `/orca07/statisticsdatav3`, both requiring an explicit `:daily` / `:monthly` mode.

**Modified**

- Services
  - `OrcaApi::StatisticsFormService` — add `create_report(program_name:, parameters:, mode:)` (Request_Number 01) against `/orca51/statisticsformv3`, reusing `extract_statistics_parameter_information` for the request parameters.
- Client
  - `OrcaApi::Client` — register `StatisticsDataService` (`new_statistics_data_service`); in `#call`, rescue non-`HttpError` `StandardError` so connection failures still reach `after_call`.
